### PR TITLE
Fix Undeliverable exception in RxJava 2

### DIFF
--- a/leku/src/main/java/com/schibstedspain/leku/geocoder/AndroidGeocoderDataSource.java
+++ b/leku/src/main/java/com/schibstedspain/leku/geocoder/AndroidGeocoderDataSource.java
@@ -18,12 +18,12 @@ public class AndroidGeocoderDataSource implements GeocoderInteractorDataSource {
 
   @Override
   public Observable<List<Address>> getFromLocationName(String query) {
-    return Observable.create(subscriber -> {
+    return Observable.create(emitter -> {
       try {
-        subscriber.onNext(geocoder.getFromLocationName(query, MAX_RESULTS));
-        subscriber.onComplete();
+        emitter.onNext(geocoder.getFromLocationName(query, MAX_RESULTS));
+        emitter.onComplete();
       } catch (IOException e) {
-        subscriber.onError(e);
+        emitter.tryOnError(e);
       }
     });
   }
@@ -31,25 +31,25 @@ public class AndroidGeocoderDataSource implements GeocoderInteractorDataSource {
   @Override
   public Observable<List<Address>> getFromLocationName(String query, LatLng lowerLeft,
       LatLng upperRight) {
-    return Observable.create(subscriber -> {
+    return Observable.create(emitter -> {
       try {
-        subscriber.onNext(geocoder.getFromLocationName(query, MAX_RESULTS, lowerLeft.latitude,
+        emitter.onNext(geocoder.getFromLocationName(query, MAX_RESULTS, lowerLeft.latitude,
             lowerLeft.longitude, upperRight.latitude, upperRight.longitude));
-        subscriber.onComplete();
+        emitter.onComplete();
       } catch (IOException e) {
-        subscriber.onError(e);
+        emitter.tryOnError(e);
       }
     });
   }
 
   @Override
   public Observable<List<Address>> getFromLocation(double latitude, double longitude) {
-    return Observable.create(subscriber -> {
+    return Observable.create(emitter -> {
       try {
-        subscriber.onNext(geocoder.getFromLocation(latitude, longitude, MAX_RESULTS));
-        subscriber.onComplete();
+        emitter.onNext(geocoder.getFromLocation(latitude, longitude, MAX_RESULTS));
+        emitter.onComplete();
       } catch (IOException e) {
-        subscriber.onError(e);
+        emitter.tryOnError(e);
       }
     });
   }


### PR DESCRIPTION
We have this crash:

```
Fatal Exception: io.reactivex.exceptions.UndeliverableException: java.io.IOException: grpc failed
       at io.reactivex.plugins.RxJavaPlugins.onError(RxJavaPlugins.java:349)
       at io.reactivex.internal.operators.observable.ObservableCreate$CreateEmitter.onError(ObservableCreate.java:74)
       at com.schibstedspain.leku.geocoder.AndroidGeocoderDataSource.lambda$getFromLocation$2$AndroidGeocoderDataSource(AndroidGeocoderDataSource.java:52)
       at com.schibstedspain.leku.geocoder.AndroidGeocoderDataSource$$Lambda$2.subscribe(Unknown Source)
       at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40)
       at io.reactivex.Observable.subscribe(Observable.java:10955)
       at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
       at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:452)
       at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:61)
       at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:52)
       at java.util.concurrent.FutureTask.run(FutureTask.java:237)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:154)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:269)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
       at java.lang.Thread.run(Thread.java:818)
Caused by java.io.IOException: grpc failed
       at android.location.Geocoder.getFromLocation(Geocoder.java:136)
       at com.schibstedspain.leku.geocoder.AndroidGeocoderDataSource.lambda$getFromLocation$2$AndroidGeocoderDataSource(AndroidGeocoderDataSource.java:49)
       at com.schibstedspain.leku.geocoder.AndroidGeocoderDataSource$$Lambda$2.subscribe(Unknown Source)
       at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40)
       at io.reactivex.Observable.subscribe(Observable.java:10955)
       at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
       at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:452)
       at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:61)
       at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:52)
       at java.util.concurrent.FutureTask.run(FutureTask.java:237)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:154)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:269)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
       at java.lang.Thread.run(Thread.java:818)
```

This happens because the Exception can't be delivered but RxJava 2 doesn't swallow any Exceptions. See https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling and https://stackoverflow.com/a/43525858/4034572 to know more about this.

There are 3 ways to avoid this crash:

1. Use `RxJavaPlugins.setErrorHandler(e -> { });`. This would not really fix the source of problem; would be like hiding the shit under the carpet :(
2. Check `emitter.isDisposed()` before calling `onError()`. See https://github.com/ReactiveX/RxJava/issues/4863#issuecomment-282980001
3. Use `tryOnError()` instead of `onError()` which doesn't throw the Exception if the emission is not allowed to happen due to lifecycle restrictions. See https://github.com/ReactiveX/RxJava/issues/4863#issuecomment-334943002 and http://reactivex.io/RxJava/javadoc/io/reactivex/ObservableEmitter.html#tryOnError-java.lang.Throwable-

I've chosen the 3rd option.