### PR TITLE
Added proguard rules for Reactive Location library

### DIFF
--- a/leku/lib-proguard-rules.txt
+++ b/leku/lib-proguard-rules.txt
@@ -18,3 +18,8 @@
 
 # Retrolambda
 -dontwarn java.lang.invoke.*
+
+# Reactive Location Provider 2
+-dontwarn pl.charmas.android.reactivelocation2.**
+-keep interface pl.charmas.android.reactivelocation2.** { *; }
+-keep class pl.charmas.android.reactivelocation2.** { *; }


### PR DESCRIPTION
Looks like ReactiveLocation2 could give some troubles to release version with proguard. Let's add the rules!