### PR TITLE
Reverted version on Readme until Bintray plugin fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Component library for Android that uses Google Maps and returns a latitude, long
 
 minSdkVersion >= 15<br/>
 Google Play Services = 15.0.1<br/>
-Support Library = 28.0.0
+Support Library = 27.1.1
 
 ### Download
 
@@ -83,14 +83,14 @@ Include the dependency in your app `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.schibstedspain.android:leku:5.1.0'
+    implementation 'com.schibstedspain.android:leku:5.0.0'
 }
 ```
 
 Alternatively, if you are using a different version of Google Play Services than `15.0.1` use this instead:
 
 ```groovy
-implementation ('com.schibstedspain.android:leku:5.1.0') {
+implementation ('com.schibstedspain.android:leku:5.0.0') {
     exclude group: 'com.google.android.gms'
     exclude group: 'com.android.support'
 }


### PR DESCRIPTION
There is an issue with the Bintray plugin so it's not possible for now to upload a new version, so for now I've decided to revert the Readme changes related to the new version to not confuse the users.