### PR TITLE
Try the Novoda plugin SNAPSHOT-6 to release the new leku version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,16 @@ buildscript {
     maven {
       url  "https://dl.bintray.com/ferranpons/maven"
     }
+    maven {
+	  url "https://novoda.bintray.com/snapshots"
+    }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.0'
+    classpath 'com.android.tools.build:gradle:3.2.1'
 
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.0"
-    classpath 'com.novoda:bintray-release:0.8.1'
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1"
+    classpath 'com.novoda:bintray-release:SNAPSHOT-6'
     classpath 'com.ferranpons:twitter-gradle-plugin:1.0.2'
     classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:4.1.0"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
## Description
We cannot publish a new release version because the Novoda plugin fails with the latest gradle wrapper. So we are going to test the latest snapshot version that upgrades the plugin to a newer gradle version.

## How has this been tested?
No tests

## Screenshots
No Screens