### PR TITLE
removed depricated method parameter for GeoDataClient Object

### DIFF
--- a/leku/src/main/java/com/schibstedspain/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/LocationPickerActivity.kt
@@ -226,7 +226,7 @@ class LocationPickerActivity : AppCompatActivity(),
     }
 
     private fun setUpMainVariables() {
-        val placesDataSource = GooglePlacesDataSource(Places.getGeoDataClient(this, null))
+        val placesDataSource = GooglePlacesDataSource(Places.getGeoDataClient(this))
         val geocoder = Geocoder(this, Locale.getDefault())
         apiInteractor = GoogleGeocoderDataSource(NetworkClient(), AddressBuilder())
         val geocoderRepository = GeocoderRepository(AndroidGeocoderDataSource(geocoder), apiInteractor!!)


### PR DESCRIPTION
removed depricate param for getGeoDataClient.

reference:https://developers.google.com/android/reference/com/google/android/gms/location/places/Places.html#getGeoDataClient(android.app.Activity)

It has been stated in google docs to use the updated method for creating getGeoDataClient object.

## How has this been tested?

![screen shot 2018-10-23 at 15 04 22](https://user-images.githubusercontent.com/6648152/47350477-97525900-d6d3-11e8-92a7-3edad6a853a7.png)

