### PR TITLE
Exclude kotlin files for Javadoc

### DIFF
--- a/leku/build.gradle
+++ b/leku/build.gradle
@@ -116,7 +116,7 @@ task androidJavadocs(type: Javadoc) {
 			owner.classpath += variant.javaCompile.classpath
 		}
 	}
-	exclude '**/R.html', '**/R.*.html', '**/index.html'
+	exclude '**/R.html', '**/R.*.html', '**/index.html', '**/*.kt'
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {


### PR DESCRIPTION
We need to exclude Kotlin files when executing javadoc task

![mistake](https://media.giphy.com/media/80TEu4wOBdPLG/giphy.gif)